### PR TITLE
Proposed changes (typo / exclude created_at, updated_at.. fields) 

### DIFF
--- a/src/Models/Field.php
+++ b/src/Models/Field.php
@@ -440,7 +440,7 @@ class Field
             'is-primary' => $this->isPrimary,
             'comment' => $this->comment,
             'is-nullable' => $this->isNullable,
-            'is-unsiged' => $this->isUnsigned,
+            'is-unsigned' => $this->isUnsigned,
             'is-auto-increment' => $this->isAutoIncrement,
             'is-inline-options' => $this->isInlineOptions,
             'is-multiple-answers' => $this->isMultipleAnswers,

--- a/src/Support/FieldOptimizer.php
+++ b/src/Support/FieldOptimizer.php
@@ -115,7 +115,6 @@ class FieldOptimizer extends OptimizerBase
     {
         if (empty($this->field->dateFormat) && $this->field->isDateOrTime()) {
             $this->field->dateFormat = 'm/d/Y H:i A';
-	        if ( in_array ( $this->field->name, ['created_at', 'updated_at', 'deleted_at'] ) ) $this->field->isOnFormView = false;
         }
 
         return $this;

--- a/src/Support/FieldOptimizer.php
+++ b/src/Support/FieldOptimizer.php
@@ -115,6 +115,7 @@ class FieldOptimizer extends OptimizerBase
     {
         if (empty($this->field->dateFormat) && $this->field->isDateOrTime()) {
             $this->field->dateFormat = 'm/d/Y H:i A';
+	        if ( in_array ( $this->field->name, ['created_at', 'updated_at', 'deleted_at'] ) ) $this->field->isOnFormView = false;
         }
 
         return $this;


### PR DESCRIPTION
I believe it's better to set the "is-on-form" option (in the file field generated from an existing table) to false; 
as 'created_at', 'updated_at', 'deleted_at' are automatically managed by Eloquent, this change removes them from the form view and the model's fillable array. 
It would probably be better to generalize and implement a configurable option, but I find this useful as a starting point and a good default (without digging too much in the code :) )