### PR TITLE
Include Trait to fix undefined FieldTransformer::getModelsPath() error

### DIFF
--- a/src/Support/FieldTransformer.php
+++ b/src/Support/FieldTransformer.php
@@ -12,7 +12,9 @@ use CrestApps\CodeGenerator\Models\ForeignRelationship;
 
 class FieldTransformer
 {
-
+	
+	use CommonCommand;
+	
     /**
      * The raw field before transformation
      *


### PR DESCRIPTION
Include CommonCommand Trait to fix “Call to undefined method CrestApps\CodeGenerator\Support\FieldTransformer::getModelsPath()” error in resource generation

I got the error while generating resources (from fields-file).
It seems it was just the CommonCommand Trait missing in FieldTransformer.
   