### PR TITLE
Missing semicolon in templates’ model-relation stub

### DIFF
--- a/templates/default-collective/model-relation.stub
+++ b/templates/default-collective/model-relation.stub
@@ -3,5 +3,5 @@
      */
     public function {{relationName}}()
     {
-        return $this->{{relationType}}({{relationParams}})
+        return $this->{{relationType}}({{relationParams}});
     }

--- a/templates/default/model-relation.stub
+++ b/templates/default/model-relation.stub
@@ -3,5 +3,5 @@
      */
     public function {{relationName}}()
     {
-        return $this->{{relationType}}({{relationParams}})
+        return $this->{{relationType}}({{relationParams}});
     }


### PR DESCRIPTION
Just a typo