### PR TITLE
Changed the Trait

### DIFF
--- a/src/Traits/CommonCommand.php
+++ b/src/Traits/CommonCommand.php
@@ -7,11 +7,11 @@ use File;
 use Exception;
 use CrestApps\CodeGenerator\Support\Helpers;
 use CrestApps\CodeGenerator\Models\Field;
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 
 trait CommonCommand
 {
-    use AppNamespaceDetectorTrait;
+    use DetectsApplicationNamespace;
     /**
      * The default route actions
      *


### PR DESCRIPTION
PHP Fatal error:  Trait 'Illuminate\Console\AppNamespaceDetectorTrait' not found in 
/vendor/crestapps/laravel-code-generator/src/Traits/CommonCommand.php on line 14
                          
  [Symfony\Component\Debug\Exception\FatalErrorException]         
  Trait 'Illuminate\Console\AppNamespaceDetectorTrait' not found