### PR TITLE
Undefined method: getForeignKeyToRaw() - Probable typo

### DIFF
--- a/src/Models/Field.php
+++ b/src/Models/Field.php
@@ -512,7 +512,7 @@ class Field
             'delimiter' => $this->optionsDelimiter,
             'range' => $this->range,
             'foreign-relation' => $this->getForeignRelationToRaw(),
-            'foreign-constraint' => $this->getForeignKeyToRaw()
+            'foreign-constraint' => $this->getForeignConstraintToRaw ()
         ];
     }
 


### PR DESCRIPTION
Undefined method error - I suppose it had to be getForeignConstraintToRaw()
Didn't check any further, but I got the error while generating a fields file - changing the name, it worked 