### PR TITLE
Add custom language plurals for non-english languages

### DIFF
--- a/src/Traits/GeneratorReplacers.php
+++ b/src/Traits/GeneratorReplacers.php
@@ -16,7 +16,14 @@ trait GeneratorReplacers
     protected function replaceModelName(&$stub, $modelName)
     {
         $englishSingle = $this->modelNamePlainEnglish($modelName);
-        $plural = str_plural($englishSingle);
+        
+        //allow custom plurals in the case that str_plural doesn't work fine in your language
+        if(config('codegenerator.plurals') && array_key_exists($englishSingle,config('codegenerator.plurals'))){
+            $plural = config('codegenerator.plurals')[$englishSingle];
+        }
+        else{
+            $plural = str_plural($englishSingle);            
+        } 
 
         $stub = $this->strReplace('model_name', $englishSingle, $stub);
         $stub = $this->strReplace('model_name_flat', strtolower($modelName), $stub);   


### PR DESCRIPTION
In languages other than english, str_plural sometimes don't work fine. 

With this improvement, just add those custom plurals in config/codegenerator like this:

'plurals'=>[
        'lugar'=>'lugares',
    ]

if the key doesn't exist, it behaves as usual.
