### PR TITLE
Extend relation types to include MorphOne

### DIFF
--- a/src/Models/ForeignRelationship.php
+++ b/src/Models/ForeignRelationship.php
@@ -27,6 +27,7 @@ class ForeignRelationship implements JsonWriter
         'hasManyThrough',
         'morphTo',
         'morphMany',
+        'morphOne',
         'morphToMany',
     ];
 
@@ -107,6 +108,7 @@ class ForeignRelationship implements JsonWriter
         return in_array($this->type, [
             'hasOne',
             'belongsTo',
+            'morphOne',
             'morphTo',
         ]);
     }

--- a/src/Models/ForeignRelationship.php
+++ b/src/Models/ForeignRelationship.php
@@ -123,7 +123,7 @@ class ForeignRelationship implements JsonWriter
     public function setType($type)
     {
         if (!self::isValidType($type)) {
-            throw new OutOfRangeException();
+            throw new \OutOfRangeException();
         }
 
         $this->type = $type;


### PR DESCRIPTION
As it says on the tin, add MorphOne to the list of allowed and also to single-model relations.

Also fix a missed reference to OutOfRangeException that I tripped over while trying to generate a MorphOne relation.